### PR TITLE
Rework & new features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ dynamic = ["version", "description"]
 
 [project.urls]
 Home = "https://github.com/European-XFEL/sfollow"
+
+[project.scripts]
+sfollow = "sfollow.sfollow:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [{name = "European XFEL GmbH", email = "da-support@xfel.eu"}]
 readme = "README.rst"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: BSD License"]
+dependencies = ["trio"]
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [{name = "European XFEL GmbH", email = "da-support@xfel.eu"}]
 readme = "README.rst"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: BSD License"]
-dependencies = ["trio"]
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/sfollow.py
+++ b/sfollow.py
@@ -49,7 +49,8 @@ async def watch_jobs(job_ids, nursery):
         if state not in STATES_NOT_STARTED:
             info = get_job_info(job_id)
             for path in get_std_streams(info):
-                nursery.start_soon(tail_log, path, job_id)
+                cscope = nursery.start(tail_log, path)
+                tail_cancels[job_id].append(cscope)
 
     spinner = '|/-\\'
     spinner_i = 0

--- a/sfollow.py
+++ b/sfollow.py
@@ -137,7 +137,7 @@ def get_std_streams(job_info):
         paths.append(job_info['StdErr'])
 
     if len(paths) == 2 and os.path.samefile(paths[0],  paths[1]):
-        print("Stdout & stderr in the same file")
+        # Stdout & stderr in the same file
         del paths[1]
 
     return paths
@@ -168,7 +168,7 @@ def main():
     else:
         job_id, job_name = my_last_job()
         job_ids = [job_id]
-        print(f"Following your most recent job: {job_id} ({job_name})")
+        print(f"[sfollow] Following your most recent job: {job_id} ({job_name})")
     trio.run(sfollow, job_ids)
 
 if __name__ == '__main__':

--- a/sfollow.py
+++ b/sfollow.py
@@ -20,7 +20,8 @@ STATES_NOT_STARTED = {'PENDING', 'CONFIGURING'}
 
 def job_states(job_ids):
     res = run([
-        'squeue', '--noheader', '--format=%i %T', '--jobs', ','.join(job_ids)
+        'squeue', '--noheader', '--format=%i %T', '--jobs', ','.join(job_ids),
+        '--states=all',
     ], stdout=PIPE, stderr=PIPE, encoding='utf-8', check=True)
     return dict([l.strip().partition(' ')[::2] for l in res.stdout.splitlines()])
 

--- a/sfollow.py
+++ b/sfollow.py
@@ -49,7 +49,7 @@ async def watch_jobs(job_ids, nursery):
         if state not in STATES_NOT_STARTED:
             info = get_job_info(job_id)
             for path in get_std_streams(info):
-                cscope = nursery.start(tail_log, path)
+                cscope = await nursery.start(tail_log, path)
                 tail_cancels[job_id].append(cscope)
 
     spinner = '|/-\\'
@@ -76,7 +76,7 @@ async def watch_jobs(job_ids, nursery):
                 info = get_job_info(job_id)
                 print(f"[sfollow] Job {job_id} ({info.get('JobName', '')}) started")
                 for i, path in enumerate(get_std_streams(info)):
-                    cscope = nursery.start(tail_log, path, True)
+                    cscope = await nursery.start(tail_log, path, True)
                     tail_cancels[job_id].append(cscope)
 
             finished = new_state in STATES_FINISHED

--- a/sfollow.py
+++ b/sfollow.py
@@ -105,14 +105,14 @@ async def tail_log(path, newly_started=False, *, task_status=trio.TASK_STATUS_IG
 
             while True:
                 for line in sr:
-                    print(line)
+                    print(line, end='')
                 await trio.sleep(0.5)
 
         # The Slurm job has finished - this should catch any final output
         # Not unreachable, see https://youtrack.jetbrains.com/issue/PY-34484
         # noinspection PyUnreachableCode
         for line in sr:
-            print(line)
+            print(line, end='')
 
 
 def get_job_info(job_id):

--- a/sfollow/__init__.py
+++ b/sfollow/__init__.py
@@ -1,0 +1,3 @@
+"""Follow the output of a Slurm batch job"""
+
+__version__ = '0.1'

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -1,5 +1,3 @@
-"""Follow the output of a Slurm batch job"""
-
 import codecs
 import os
 import re
@@ -8,8 +6,6 @@ from collections import defaultdict
 from subprocess import run, PIPE
 
 import trio
-
-__version__ = '0.1'
 
 
 STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -56,8 +56,7 @@ async def watch_jobs(job_ids, nursery):
                     cscope = await nursery.start(tail_log, path, True)
                     tail_cancels[job_id].append(cscope)
 
-            finished = new_state in STATES_FINISHED
-            if finished and states[job_id] not in STATES_FINISHED:
+            if new_state in STATES_FINISHED:
                 # Job finished since the last check
                 for cscope in tail_cancels.pop(job_id):
                     cscope.cancel()

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -68,7 +68,7 @@ def sfollow(job_ids):
                 # Job finished since the last check
                 for fh in open_files.pop(job_id, ()):
                     # strip any trailing newline, let print() add one.
-                    print(fh.read().replace('utf-8', 'replace').rstrip('\n'))
+                    print(fh.read().decode('utf-8', 'replace').rstrip('\n'))
                     fh.close()
 
                 msg(f'Job {job_id} finished ({fmt_state(new_state)})')

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -1,11 +1,10 @@
-import codecs
+import itertools
 import os
 import re
 import sys
+import time
 from collections import defaultdict
 from subprocess import run, PIPE
-
-import trio
 
 from .terminal import msg, spinner_msg, clear_spinner, fmt_state, fmt_jobs
 
@@ -24,73 +23,62 @@ def job_states(job_ids):
     return dict([l.strip().partition(' ')[::2] for l in res.stdout.splitlines()])
 
 
-async def watch_jobs(job_ids, nursery):
+def sfollow(job_ids):
     states = job_states(job_ids)
-    tail_cancels = defaultdict(list)
+    open_files = defaultdict(list)
 
+    # Jobs already running before we started: jump to near the end, like tail -f
     for job_id, state in states.items():
         if state not in STATES_NOT_STARTED:
             info = get_job_info(job_id)
             for path in get_std_streams(info):
-                cscope = await nursery.start(tail_log, path)
-                tail_cancels[job_id].append(cscope)
+                fh = open(path, 'rb')
+                if os.stat(fh.fileno()).st_size > 512:
+                    fh.seek(-512, os.SEEK_END)
+                open_files[job_id].append(fh)
 
-    while True:
-        job_ids_unfinished = [
-            j for (j, s) in states.items() if s not in STATES_FINISHED
-        ]
+    for i in itertools.count():
+        for files in open_files.values():
+            for f in files:
+                for line in f:
+                    print(line.decode('utf-8', 'replace'), end='')
 
-        if all(st in STATES_NOT_STARTED for st in states.values()):
-            spinner_msg(f"Waiting for {fmt_jobs(job_ids)} to start")
+        # Check for jobs started/finished every 4th cycle (2 seconds)
+        if i % 4 == 0:
+            if not open_files:
+                spinner_msg(f"Waiting for {fmt_jobs(job_ids)} to start")
 
-        for job_id, new_state in job_states(job_ids_unfinished).items():
+            new_states = job_states([
+                j for (j, s) in states.items() if s not in STATES_FINISHED
+            ])
+        else:
+            new_states = {}
+
+        for job_id, new_state in new_states.items():
             started = new_state not in STATES_NOT_STARTED
             if started and states[job_id] in STATES_NOT_STARTED:
                 # Job started since the last check
                 info = get_job_info(job_id)
                 clear_spinner()
                 msg(f"Job {job_id} ({info.get('JobName', '')}) started")
-                for i, path in enumerate(get_std_streams(info)):
-                    cscope = await nursery.start(tail_log, path, True)
-                    tail_cancels[job_id].append(cscope)
+                for path in get_std_streams(info):
+                    open_files[job_id].append(open(path, 'rb'))
 
             if new_state in STATES_FINISHED:
                 # Job finished since the last check
-                for cscope in tail_cancels.pop(job_id):
-                    cscope.cancel()
+                for fh in open_files.pop(job_id, ()):
+                    # strip any trailing newline, let print() add one.
+                    print(fh.read().replace('utf-8', 'replace').rstrip('\n'))
+                    fh.close()
 
-                # Fudge - hopefully final output will show before 'finished' msg
-                await trio.sleep(0.01)
                 msg(f'Job {job_id} finished ({fmt_state(new_state)})')
 
             states[job_id] = new_state
 
         if all(st in STATES_FINISHED for st in states.values()):
-            break
+            break  # All jobs finished, sfollow can exit
 
-        await trio.sleep(2)
-
-
-async def tail_log(path, newly_started=False, *, task_status=trio.TASK_STATUS_IGNORED):
-    with open(path, 'rb') as fh:
-        if not newly_started and os.stat(fh.fileno()).st_size > 512:
-            fh.seek(-512, os.SEEK_END)
-
-        sr = codecs.getreader('utf-8')(fh, 'replace')
-
-        with trio.CancelScope() as cscope:
-            task_status.started(cscope)
-
-            while True:
-                for line in sr:
-                    print(line, end='')
-                await trio.sleep(0.5)
-
-        # The Slurm job has finished - this should catch any final output
-        # Not unreachable, see https://youtrack.jetbrains.com/issue/PY-34484
-        # noinspection PyUnreachableCode
-        for line in sr:
-            print(line, end='')
+        time.sleep(0.5)
 
 
 def get_job_info(job_id):
@@ -120,14 +108,6 @@ def get_std_streams(job_info):
     return paths
 
 
-async def sfollow(job_ids):
-    """Follow the output from a SLURM batch job"""
-    async with trio.open_nursery() as nursery:
-        nursery.start_soon(watch_jobs, job_ids, nursery)
-    # The nursery waits for all child tasks to finish, which should happen
-    # shortly after the Slurm jobs in question finish.
-
-
 def my_last_job():
     # '--format=%i %j' gives job IDs & names
     # --sort=-V sorts by submission time (descending)
@@ -146,7 +126,7 @@ def main():
         job_id, job_name = my_last_job()
         job_ids = [job_id]
         msg(f"Following your most recent job: {job_id} ({job_name})")
-    trio.run(sfollow, job_ids)
+    sfollow(job_ids)
 
 if __name__ == '__main__':
     main()

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -126,14 +126,14 @@ def my_last_job():
 
 
 def main():
-    if len(sys.argv) >= 2:
-        job_ids = sys.argv[1:]
-    else:
-        job_id, job_name = my_last_job()
-        job_ids = [job_id]
-        msg(f"Following your most recent job: {job_id} ({job_name})")
+    job_ids = sys.argv[1:]
 
     try:
+        if not job_ids:
+            job_id, job_name = my_last_job()
+            job_ids = [job_id]
+            msg(f"Following your most recent job: {job_id} ({job_name})")
+
         sfollow(job_ids)
     except (KeyboardInterrupt, UsageError) as e:
         clear_spinner()

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -68,7 +68,9 @@ def sfollow(job_ids):
                 # Job finished since the last check
                 for fh in open_files.pop(job_id, ()):
                     # strip any trailing newline, let print() add one.
-                    print(fh.read().decode('utf-8', 'replace').rstrip('\n'))
+                    b = fh.read()
+                    if b:
+                        print(b.decode('utf-8', 'replace').rstrip('\n'))
                     fh.close()
 
                 msg(f'Job {job_id} finished ({fmt_state(new_state)})')

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -39,8 +39,6 @@ async def watch_jobs(job_ids, nursery):
         job_ids_unfinished = [
             j for (j, s) in states.items() if s not in STATES_FINISHED
         ]
-        if not job_ids_unfinished:
-            break
 
         if all(st in STATES_NOT_STARTED for st in states.values()):
             spinner_msg(f"Waiting for {fmt_jobs(job_ids)} to start")
@@ -66,6 +64,9 @@ async def watch_jobs(job_ids, nursery):
                 msg(f'Job {job_id} finished ({fmt_state(new_state)})')
 
             states[job_id] = new_state
+
+        if all(st in STATES_FINISHED for st in states.values()):
+            break
 
         await trio.sleep(2)
 

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -62,8 +62,8 @@ async def watch_jobs(job_ids, nursery):
                 for cscope in tail_cancels.pop(job_id):
                     cscope.cancel()
 
-                # Checkpoint - let tail tasks process any final output
-                await trio.sleep(0)
+                # Fudge - hopefully final output will show before 'finished' msg
+                await trio.sleep(0.01)
                 msg(f'Job {job_id} finished ({fmt_state(new_state)})')
 
             states[job_id] = new_state

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -44,14 +44,13 @@ async def watch_jobs(job_ids, nursery):
 
         if all(st in STATES_NOT_STARTED for st in states.values()):
             spinner_msg(f"Waiting for {fmt_jobs(job_ids)} to start")
-        else:
-            clear_spinner()
 
         for job_id, new_state in job_states(job_ids_unfinished).items():
             started = new_state not in STATES_NOT_STARTED
             if started and states[job_id] in STATES_NOT_STARTED:
                 # Job started since the last check
                 info = get_job_info(job_id)
+                clear_spinner()
                 msg(f"Job {job_id} ({info.get('JobName', '')}) started")
                 for i, path in enumerate(get_std_streams(info)):
                     cscope = await nursery.start(tail_log, path, True)

--- a/sfollow/terminal.py
+++ b/sfollow/terminal.py
@@ -1,0 +1,39 @@
+import sys
+from shutil import get_terminal_size
+
+def fmt_jobs(job_ids):
+    if len(job_ids) == 1:
+        return f"Job {job_ids[0]}"
+    elif len(job_ids) <= 3:
+        return f"Jobs {','.join(job_ids)}"
+    else:
+        return f"{len(job_ids)} jobs"
+
+def fmt_state(state):
+    red, green, reset = '\x1b[31m', '\x1b[32m', '\x1b[0m'
+    if state == 'COMPLETED':
+        return f'{green}{state}{reset}'
+    else:  # For now, treat finishing any other way as undesirable
+        return f'{red}{state}{reset}'
+
+def msg(s):
+    print('[sfollow]', s, file=sys.stderr)
+
+spinner_i = 0
+spinner_parts = '|/-\\'
+spinner_shown = False
+
+def spinner_msg(s):
+    global spinner_i, spinner_shown
+    c = spinner_parts[spinner_i]
+    print('[sfollow]', c, s, end='\r', file=sys.stderr)
+
+    spinner_shown = True
+    spinner_i = (spinner_i + 1) % len(spinner_parts)
+
+def clear_spinner():
+    global spinner_shown
+    if spinner_shown:
+        cols, _ = get_terminal_size()
+        print(' ' * cols, end='\r')
+        spinner_shown = False


### PR DESCRIPTION
New features:

- If no job is specified, find the user's last-submitted job (that hasn't yet finished)
- If jobs are pending, wait for them to start before trying to read logs
- When jobs are finished, `sfollow` exits.

Collectively, this makes it quite convenient to run `sbatch ...` and then `sfollow` to watch the job run.

The code is basically totally rewritten. I realised that my previous attempt to wait for new data in the file was never actually waiting - it just worked as a busy-loop. So it now just sleeps for a bit and then checks for updates. It checks for new output every 0.5 seconds, and for jobs starting/finishing every 2 seconds.