### PR TITLE
Allow specifying non-default cluster

### DIFF
--- a/sfollow/__main__.py
+++ b/sfollow/__main__.py
@@ -1,0 +1,2 @@
+from .sfollow import main
+main()


### PR DESCRIPTION
We've recently started using a non-default cluster for some things, and I want to be able to `sfollow` jobs running there.

The `-M` or `--clusters` option matches the name on all of the Slurm commands I checked (sbatch, sinfo, etc.).