### PR TITLE
Fix for empty StdErr= in scontrol output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
 name = "sfollow"
 authors = [{name = "European XFEL GmbH", email = "da-support@xfel.eu"}]
 readme = "README.rst"
-license = {file = "LICENSE"}
-classifiers = ["License :: OSI Approved :: BSD License"]
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
+requires-python = ">=3.8"
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/sfollow/sfollow.py
+++ b/sfollow/sfollow.py
@@ -111,10 +111,10 @@ def get_std_streams(job_info):
     If they are the same file, only keep one.
     """
     paths = []
-    if 'StdOut' in job_info:
-        paths.append(job_info['StdOut'])
-    if 'StdErr' in job_info:
-        paths.append(job_info['StdErr'])
+    if so := job_info.get('StdOut', ''):
+        paths.append(so)
+    if se := job_info.get('StdErr', ''):
+        paths.append(se)
 
     if len(paths) == 2 and os.path.samefile(paths[0],  paths[1]):
         # Stdout & stderr in the same file


### PR DESCRIPTION
If no separate stderr path is used, scontrol used to show the stdout path for both. Now it shows `StdErr=` with no path instead, which broke sfollow for those jobs. This fixes it again.